### PR TITLE
Fix wrong option names being passed from cli to handler

### DIFF
--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -1,6 +1,13 @@
 {
   "issues": [
     {
+      "id": 1088756681,
+      "number": 24,
+      "submitter": "joachimdalen",
+      "title": "Changelog has mismatch between options and names",
+      "url": "https://github.com/joachimdalen/azext/issues/24"
+    },
+    {
       "id": 1088623657,
       "number": 22,
       "submitter": "joachimdalen",
@@ -37,6 +44,13 @@
     }
   ],
   "pullRequests": [
+    {
+      "id": 810008546,
+      "number": 25,
+      "submitter": "joachimdalen",
+      "title": "Fix wrong option names being passed from cli to handler",
+      "url": "https://github.com/joachimdalen/azext/pull/25"
+    },
     {
       "id": 809910833,
       "number": 23,

--- a/.azext/changelog.json
+++ b/.azext/changelog.json
@@ -12,6 +12,34 @@
             "description": "Fix GitHub pull requests getting the wrong link title",
             "issue": 22,
             "pullRequest": 23
+          },
+          {
+            "type": "fix",
+            "description": "Fix certain cli options not passing the correct value to handler",
+            "issue": 24,
+            "pullRequest": 25
+          }
+        ]
+      },
+      {
+        "name": "readme",
+        "version": "0.2.2",
+        "changes": [
+          {
+            "type": "other",
+            "description": "Refactor how cli parameters are set in the cli definition",
+            "pullRequest": 25
+          }
+        ]
+      },
+      {
+        "name": "init",
+        "version": "0.2.2",
+        "changes": [
+          {
+            "type": "other",
+            "description": "Refactor how cli parameters are set in the cli definition",
+            "pullRequest": 25
           }
         ]
       }

--- a/src/cli/changelog/changelog-definition.ts
+++ b/src/cli/changelog/changelog-definition.ts
@@ -16,6 +16,20 @@ import NewChangelogConfigCmdHandler from './handlers/changelog-config-cmd-handle
 import ChangelogGenerateCmdHandler from './handlers/changelog-generate-cmd-handler';
 import NewChangelogCmdHandler from './handlers/changelog-new-cmd-handler';
 
+enum ChangelogCliNames {
+  ConfigName = 'config-name',
+  Force = 'force',
+  Output = 'output',
+  Format = 'format',
+  GenerateCache = 'generate-cache',
+  FromCache = 'from-cache',
+  CacheName = 'cache-name',
+  Version = 'version',
+  OutputName = 'output-name',
+  Fresh = 'fresh',
+  LogName = 'log-name'
+}
+
 const changelogCommands: CommandBase = {
   command: 'changelog',
   sections: [
@@ -62,13 +76,13 @@ const changelogCommands: CommandBase = {
           header: 'Options',
           optionList: [
             {
-              name: 'output',
+              name: ChangelogCliNames.Output,
               alias: 'o',
               description: 'Full path to output generated markdown file to',
               defaultValue: path.join(workingDirectory(), CHANGELOG_OUTPUT_NAME)
             },
             {
-              name: 'config-name',
+              name: ChangelogCliNames.ConfigName,
               alias: 'c',
               description:
                 'File name of configuration file. Default: ' +
@@ -76,37 +90,37 @@ const changelogCommands: CommandBase = {
               defaultValue: CHANGELOG_CONFIG_NAME
             },
             {
-              name: 'log-name',
+              name: ChangelogCliNames.LogName,
               alias: 'l',
               description:
                 'File name of changelog entry file. Default: ' + CHANGELOG_NAME,
               defaultValue: CHANGELOG_NAME
             },
             {
-              name: 'format',
+              name: ChangelogCliNames.Format,
               type: Boolean,
               defaultValue: true,
               description:
                 'Format generated file. Requires Prettier to be installed'
             },
             {
-              name: 'generate-cache',
+              name: ChangelogCliNames.GenerateCache,
               type: Boolean,
               defaultValue: true,
               description: `Generate ${CHANGELOG_CACHE_NAME} containing a cache of issues and pull requests`
             },
             {
-              name: 'from-cache',
+              name: ChangelogCliNames.FromCache,
               type: Boolean,
               defaultValue: true,
               description: `Load issues and pull requests from cache file before GitHub`
             },
             {
-              name: 'cache-name',
+              name: ChangelogCliNames.CacheName,
               defaultValue: CHANGELOG_CACHE_NAME
             },
             {
-              name: 'version',
+              name: ChangelogCliNames.Version,
               type: String,
               description:
                 'Generate changelog for only this version. Maps to the version field of changelog.json'
@@ -116,44 +130,44 @@ const changelogCommands: CommandBase = {
       ],
       options: [
         {
-          name: 'output',
+          name: ChangelogCliNames.Output,
           alias: 'o',
 
           defaultValue: path.join(workingDirectory(), CHANGELOG_OUTPUT_NAME)
         },
         {
-          name: 'config-name',
+          name: ChangelogCliNames.ConfigName,
           alias: 'c',
 
           defaultValue: CHANGELOG_CONFIG_NAME
         },
         {
-          name: 'log-name',
+          name: ChangelogCliNames.LogName,
           alias: 'l',
 
           defaultValue: CHANGELOG_NAME
         },
         {
-          name: 'format',
+          name: ChangelogCliNames.Format,
           type: Boolean,
           defaultValue: true
         },
         {
-          name: 'generate-cache',
+          name: ChangelogCliNames.GenerateCache,
           type: Boolean,
           defaultValue: true
         },
         {
-          name: 'from-cache',
+          name: ChangelogCliNames.FromCache,
           type: Boolean,
           defaultValue: true
         },
         {
-          name: 'cache-name',
+          name: ChangelogCliNames.CacheName,
           defaultValue: CHANGELOG_CACHE_NAME
         },
         {
-          name: 'version',
+          name: ChangelogCliNames.Version,
           type: String
         }
       ],
@@ -183,13 +197,13 @@ const changelogCommands: CommandBase = {
           header: 'Options',
           optionList: [
             {
-              name: 'force',
+              name: ChangelogCliNames.Force,
               description: 'Overwrite file if it exists',
               defaultValue: false,
               type: Boolean
             },
             {
-              name: 'config-name',
+              name: ChangelogCliNames.ConfigName,
               description: 'File name of configuration file',
               defaultValue: CHANGELOG_CONFIG_NAME
             }
@@ -198,12 +212,12 @@ const changelogCommands: CommandBase = {
       ],
       options: [
         {
-          name: 'force',
+          name: ChangelogCliNames.Force,
           type: Boolean,
           defaultValue: false
         },
         {
-          name: 'config-name',
+          name: ChangelogCliNames.ConfigName,
           defaultValue: CHANGELOG_CONFIG_NAME
         }
       ],
@@ -233,7 +247,7 @@ const changelogCommands: CommandBase = {
           header: 'Options',
           optionList: [
             {
-              name: 'output-name',
+              name: ChangelogCliNames.OutputName,
               alias: 'o',
               description: 'Name of new changelog'
             }
@@ -242,7 +256,7 @@ const changelogCommands: CommandBase = {
       ],
       options: [
         {
-          name: 'output-file',
+          name: ChangelogCliNames.OutputName,
           alias: 'o',
           defaultValue: CHANGELOG_NAME
         }
@@ -275,11 +289,11 @@ const changelogCommands: CommandBase = {
           header: 'Options',
           optionList: [
             {
-              name: 'fresh',
+              name: ChangelogCliNames.Fresh,
               description: 'Ignore existing cache and reload all'
             },
             {
-              name: 'config-name',
+              name: ChangelogCliNames.ConfigName,
               alias: 'c',
               description:
                 'File name of configuration file. Default: ' +
@@ -287,14 +301,14 @@ const changelogCommands: CommandBase = {
               defaultValue: CHANGELOG_CONFIG_NAME
             },
             {
-              name: 'log-name',
+              name: ChangelogCliNames.LogName,
               alias: 'l',
               description:
                 'File name of changelog entry file. Default: ' + CHANGELOG_NAME,
               defaultValue: CHANGELOG_NAME
             },
             {
-              name: 'cache-name',
+              name: ChangelogCliNames.CacheName,
               defaultValue: CHANGELOG_CACHE_NAME
             }
           ]
@@ -302,22 +316,22 @@ const changelogCommands: CommandBase = {
       ],
       options: [
         {
-          name: 'fresh',
+          name: ChangelogCliNames.Fresh,
           defaultValue: false,
           type: Boolean
         },
         {
-          name: 'config-name',
+          name: ChangelogCliNames.ConfigName,
           alias: 'c',
           defaultValue: CHANGELOG_CONFIG_NAME
         },
         {
-          name: 'log-name',
+          name: ChangelogCliNames.LogName,
           alias: 'l',
           defaultValue: CHANGELOG_NAME
         },
         {
-          name: 'cache-name',
+          name: ChangelogCliNames.CacheName,
           defaultValue: CHANGELOG_CACHE_NAME
         }
       ],

--- a/src/cli/init/init-definition.ts
+++ b/src/cli/init/init-definition.ts
@@ -6,6 +6,10 @@ import { CommandBase } from '../models';
 import InitCmdHandler from './handlers/init-cmd-handler';
 import InitMappingCmdHandler from './handlers/init-mapping-cmd-handler';
 
+enum InitOptionNames {
+  Root = 'root'
+}
+
 const initCommands: CommandBase = {
   command: 'init',
   handler: () => new InitCmdHandler(),
@@ -26,7 +30,7 @@ const initCommands: CommandBase = {
       header: 'Options',
       optionList: [
         {
-          name: 'root',
+          name: InitOptionNames.Root,
           description: 'Root folder to initialize in'
         }
       ]
@@ -51,13 +55,13 @@ const initCommands: CommandBase = {
           header: 'Options',
           optionList: [
             {
-              name: 'root',
+              name: InitOptionNames.Root,
               description: 'Root folder to initialize in'
             }
           ]
         }
       ],
-      options: [{ name: 'root', alias: 'r' }],
+      options: [{ name: InitOptionNames.Root, alias: 'r' }],
       subCommands: [defaultHelpCommand]
     },
     defaultHelpCommand

--- a/src/cli/readme/readme-definition.ts
+++ b/src/cli/readme/readme-definition.ts
@@ -6,6 +6,11 @@ import { CommandBase } from '../models';
 import ReadmeCmdHandler from './handlers/readme-cmd-handler';
 import ReadmeInitCmdHandler from './handlers/readme-init-cmd-handler';
 
+enum ReadmeOptionNames {
+  Input = 'input',
+  Output = 'output'
+}
+
 const readmeCommands: CommandBase = {
   command: 'readme',
   sections: [
@@ -50,19 +55,19 @@ const readmeCommands: CommandBase = {
           header: 'Options',
           optionList: [
             {
-              name: 'input',
+              name: ReadmeOptionNames.Input,
               description: 'Input file containing the template'
             },
             {
-              name: 'output',
+              name: ReadmeOptionNames.Output,
               description: 'Output file to write replaced value to'
             }
           ]
         }
       ],
       options: [
-        { name: 'input', alias: 'i' },
-        { name: 'output', alias: 'o' }
+        { name: ReadmeOptionNames.Input, alias: 'i' },
+        { name: ReadmeOptionNames.Output, alias: 'o' }
       ],
       subCommands: [defaultHelpCommand]
     },


### PR DESCRIPTION
Fix wrong option names being passed from cli to handler

Also implemented the same fix for `readme` and `init`