### PR TITLE
Fix not being able to initialize in a new project

### DIFF
--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -1,6 +1,13 @@
 {
   "issues": [
     {
+      "id": 1087961018,
+      "number": 21,
+      "submitter": "joachimdalen",
+      "title": "Can not initialize in a new project",
+      "url": "https://github.com/joachimdalen/azext/issues/21"
+    },
+    {
       "id": 1088756681,
       "number": 24,
       "submitter": "joachimdalen",
@@ -44,6 +51,13 @@
     }
   ],
   "pullRequests": [
+    {
+      "id": 810010044,
+      "number": 26,
+      "submitter": "joachimdalen",
+      "title": "Fix not being able to initialize in a new project",
+      "url": "https://github.com/joachimdalen/azext/pull/26"
+    },
     {
       "id": 810008546,
       "number": 25,

--- a/.azext/changelog.json
+++ b/.azext/changelog.json
@@ -40,6 +40,12 @@
             "type": "other",
             "description": "Refactor how cli parameters are set in the cli definition",
             "pullRequest": 25
+          },
+          {
+            "type": "fix",
+            "description": "Fixed an issue where the cli would look for `.azext` directory when trying to create it",
+            "issue": 21,
+            "pullRequest": 26
           }
         ]
       }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -155,7 +155,10 @@ class AzExtCli {
           'No handler defined for command ' + data.command?.command
         );
       } else {
-        if (!(await this._configProvider.hasConfigFolderInWorkingDir())) {
+        if (
+          data.command.skipDirectoryCheck === false &&
+          !(await this._configProvider.hasConfigFolderInWorkingDir())
+        ) {
           throw new Error(
             'Failed to find configuration folder in working directory'
           );

--- a/src/cli/init/handlers/init-cmd-handler.ts
+++ b/src/cli/init/handlers/init-cmd-handler.ts
@@ -8,7 +8,6 @@ export default class InitCmdHandler extends BaseCommandHandler<InitOptions> {
   private _service: InitService;
   constructor() {
     super();
-    console.log('Creating init service');
     this._service = new InitService();
   }
   async handleCommand(options: InitOptions): Promise<void> {

--- a/src/cli/init/init-definition.ts
+++ b/src/cli/init/init-definition.ts
@@ -12,6 +12,7 @@ enum InitOptionNames {
 
 const initCommands: CommandBase = {
   command: 'init',
+  skipDirectoryCheck: true,
   handler: () => new InitCmdHandler(),
   sections: [
     ...introSections,

--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -48,6 +48,7 @@ export interface CommandBase {
   sections: Section[];
   options: OptionDefinition[];
   subCommands?: CommandBase[];
+  skipDirectoryCheck?: boolean;
 }
 
 export const helpCommand: CommandBase = {


### PR DESCRIPTION
- Added new option `skipDirectoryCheck` to `CommandBase` that will skip the check for `.azext/` in the working directory
- Removed some logging