### PR TITLE
Add changes to root release

### DIFF
--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -1,6 +1,13 @@
 {
   "issues": [
     {
+      "id": 1083928439,
+      "number": 10,
+      "submitter": "joachimdalen",
+      "title": "Add changes to root release outside of individual modules",
+      "url": "https://github.com/joachimdalen/azext/issues/10"
+    },
+    {
       "id": 1088796811,
       "number": 29,
       "submitter": "joachimdalen",
@@ -58,6 +65,13 @@
     }
   ],
   "pullRequests": [
+    {
+      "id": 810212850,
+      "number": 34,
+      "submitter": "joachimdalen",
+      "title": "Add changes to root release",
+      "url": "https://github.com/joachimdalen/azext/pull/34"
+    },
     {
       "id": 810062467,
       "number": 32,

--- a/.azext/changelog-config.json
+++ b/.azext/changelog-config.json
@@ -6,10 +6,6 @@
     "format": "{{version}} ({{publishDate}})"
   },
   "moduleTitleFormat": { "size": "h4", "format": "`{{name}}@{{version}}`" },
-  "rootChangesTitle": {
-    "size": "h2",
-    "format": ":bookmark: Base changes"
-  },
   "moduleChangesTitle": {
     "size": "h2",
     "format": ":package: Module changes"
@@ -38,7 +34,6 @@
     "moduleTitle": true,
     "attributionTitle": true,
     "attributionSubTitle": true,
-    "rootChangesTitle": true,
     "moduleChangesTitle": true,
     "githubIssues": false,
     "githubPullRequests": false,

--- a/.azext/changelog-config.json
+++ b/.azext/changelog-config.json
@@ -6,6 +6,14 @@
     "format": "{{version}} ({{publishDate}})"
   },
   "moduleTitleFormat": { "size": "h4", "format": "`{{name}}@{{version}}`" },
+  "rootChangesTitle": {
+    "size": "h2",
+    "format": ":bookmark: Base changes"
+  },
+  "moduleChangesTitle": {
+    "size": "h2",
+    "format": ":package: Module changes"
+  },
   "sectionSplitter": "---",
   "typeSize": "h3",
   "typeMapping": {
@@ -30,6 +38,8 @@
     "moduleTitle": true,
     "attributionTitle": true,
     "attributionSubTitle": true,
+    "rootChangesTitle": true,
+    "moduleChangesTitle": true,
     "githubIssues": false,
     "githubPullRequests": false,
     "notes": true,

--- a/.azext/changelog.json
+++ b/.azext/changelog.json
@@ -1,22 +1,30 @@
 [
   {
     "publishDate": "2021-12-XX",
-    "version": "0.2.3",
+    "version": "0.3.0",
+    "changes": [
+      {
+        "type": "other",
+        "description": "Use standalone prettier to reduce size",
+        "pullRequest": 31
+      }
+    ],
     "modules": [
       {
-        "name": "core",
-        "version": "0.2.3",
+        "name": "changelog",
+        "version": "0.3.0",
         "changes": [
           {
-            "type": "maint",
-            "description": "Use standalone prettier to reduce size",
-            "pullRequest": 31
+            "type": "feature",
+            "description": "Added ability to add changes outside of individual modules",
+            "issue": 10,
+            "pullRequest": 34
           }
         ]
       },
       {
         "name": "readme",
-        "version": "0.2.3",
+        "version": "0.3.0",
         "changes": [
           {
             "type": "fix",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
 # Changelog
 
-## 0.2.3 (2021-12-XX)
+## 0.3.0 (2021-12-XX)
 
-### 🛠️ Maintenance (1)
-
-#### `core@0.2.3`
+### 💬 Other (1)
 
 - Use standalone prettier to reduce size
   - Pull Request: [GH#31 - Use standalone prettier](https://github.com/joachimdalen/azext/pull/31)
 
+## 📦 Module changes
+
+### 🚀 Features (1)
+
+#### `changelog@0.3.0`
+
+- Added ability to add changes outside of individual modules
+  - Issue: [GH#10 - Add changes to root release outside of individual modules](https://github.com/joachimdalen/azext/issues/10)
+  - Pull Request: [GH#34 - Add changes to root release](https://github.com/joachimdalen/azext/pull/34)
+
 ### 🐛 Fixes (1)
 
-#### `readme@0.2.3`
+#### `readme@0.3.0`
 
 - Fixed wrong fields being used when generating yaml examples
   - Issue: [GH#29 - Wrong usage example is generated](https://github.com/joachimdalen/azext/issues/29)
@@ -67,35 +75,6 @@
 
 > This release introduces a new command (`azext readme`) to manage documentation. See [GitHub Documentation](https://github.com/joachimdalen/azext/blob/master/docs/readme/index.md) for more information.
 
-### 🛠️ Maintenance (2)
-
-#### `core@0.2.0`
-
-- Split CLI and implementation in preparation for Node API
-  - Pull Request: [GH#6 - Refactor to support for usage from node](https://github.com/joachimdalen/azext/pull/6)
-- Forced path of configuration files to be in folder `.azext/`
-  - Pull Request: [GH#12 - Refactoring and docs generation](https://github.com/joachimdalen/azext/pull/12)
-
-### 🐛 Fixes (2)
-
-#### `changelog@0.2.0`
-
-- Fixed an issue with escaping characters for issue and pull request titles
-  - Pull Request: [GH#6 - Refactor to support for usage from node](https://github.com/joachimdalen/azext/pull/6)
-
-#### `init@0.2.0`
-
-- Fixed init command not respecting `--root` option
-  - Issue: [GH#2 - Init command does not respect --root option](https://github.com/joachimdalen/azext/issues/2)
-  - Pull Request: [GH#6 - Refactor to support for usage from node](https://github.com/joachimdalen/azext/pull/6)
-
-### 📝 Documentation (1)
-
-#### `core@0.2.0`
-
-- Added more detailed documentation
-  - Pull Request: [GH#7 - Update documentation](https://github.com/joachimdalen/azext/pull/7)
-
 ### 🚀 Features (9)
 
 #### `readme@0.1.0`
@@ -130,18 +109,40 @@
 - Add new command to create mapping file
   - Issue: [GH#3 - Documentation generation](https://github.com/joachimdalen/azext/issues/3)
 
+### 🐛 Fixes (2)
+
+#### `changelog@0.2.0`
+
+- Fixed an issue with escaping characters for issue and pull request titles
+  - Pull Request: [GH#6 - Refactor to support for usage from node](https://github.com/joachimdalen/azext/pull/6)
+
+#### `init@0.2.0`
+
+- Fixed init command not respecting `--root` option
+  - Issue: [GH#2 - Init command does not respect --root option](https://github.com/joachimdalen/azext/issues/2)
+  - Pull Request: [GH#6 - Refactor to support for usage from node](https://github.com/joachimdalen/azext/pull/6)
+
+### 📝 Documentation (1)
+
+#### `core@0.2.0`
+
+- Added more detailed documentation
+  - Pull Request: [GH#7 - Update documentation](https://github.com/joachimdalen/azext/pull/7)
+
+### 🛠️ Maintenance (2)
+
+#### `core@0.2.0`
+
+- Split CLI and implementation in preparation for Node API
+  - Pull Request: [GH#6 - Refactor to support for usage from node](https://github.com/joachimdalen/azext/pull/6)
+- Forced path of configuration files to be in folder `.azext/`
+  - Pull Request: [GH#12 - Refactoring and docs generation](https://github.com/joachimdalen/azext/pull/12)
+
 ---
 
 ## 0.0.1 (2021-12-13)
 
 Initial release of AzExt
-
-### 🛠️ Maintenance (1)
-
-#### `core@0.0.1`
-
-- Setup CI and CD
-  - Pull Request: [GH#1 - Setup build and deployment pipeline](https://github.com/joachimdalen/azext/pull/1)
 
 ### 🚀 Features (3)
 
@@ -156,5 +157,12 @@ Initial release of AzExt
 #### `config@0.0.1`
 
 - Added config command
+
+### 🛠️ Maintenance (1)
+
+#### `core@0.0.1`
+
+- Setup CI and CD
+  - Pull Request: [GH#1 - Setup build and deployment pipeline](https://github.com/joachimdalen/azext/pull/1)
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joachimdalen/azext",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A collection of utilities to help with extension development for Azure DevOps",
   "main": "dist/azext.js",
   "bin": {

--- a/schemas/v1/changelog-schema.json
+++ b/schemas/v1/changelog-schema.json
@@ -67,7 +67,6 @@
                     "type": "array",
                     "title": "The changes schema",
                     "description": "An explanation about the purpose of this instance.",
-
                     "items": {
                       "anyOf": [
                         {
@@ -101,6 +100,44 @@
                         }
                       ]
                     }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "changes": {
+          "type": "array",
+          "title": "The changes schema",
+          "description": "An explanation about the purpose of this instance.",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "title": "Change entry",
+                "description": "An explanation about the purpose of this instance.",
+                "required": ["description", "type"],
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "title": "The description schema",
+                    "description": "An explanation about the purpose of this instance."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "The type schema",
+                    "description": "An explanation about the purpose of this instance."
+                  },
+                  "issue": {
+                    "type": "integer",
+                    "title": "GitHub issue number",
+                    "description": "The GitHub issue number issue number of a releated GitHub issue"
+                  },
+                  "pullRequest": {
+                    "type": "integer",
+                    "title": "GitHub pull request number",
+                    "description": "The GitHub pull request number issue number of a releated GitHub pull request"
                   }
                 }
               }

--- a/src/modules/changelog/changelog-constants.ts
+++ b/src/modules/changelog/changelog-constants.ts
@@ -21,10 +21,6 @@ export const CHANGELOG_DEFAULT_CONFIG: ChangelogConfig = {
     size: 'h4',
     format: '`{{name}}@{{version}}`'
   },
-  rootChangesTitle: {
-    size: 'h3',
-    format: ':bookmark: Base changes'
-  },
   moduleChangesTitle: {
     size: 'h3',
     format: ':package: Module changes'
@@ -55,7 +51,6 @@ export const CHANGELOG_DEFAULT_CONFIG: ChangelogConfig = {
     moduleTitle: true,
     attributionTitle: true,
     attributionSubTitle: true,
-    rootChangesTitle: true,
     moduleChangesTitle: true,
     githubIssues: false,
     githubPullRequests: false,

--- a/src/modules/changelog/changelog-constants.ts
+++ b/src/modules/changelog/changelog-constants.ts
@@ -21,6 +21,14 @@ export const CHANGELOG_DEFAULT_CONFIG: ChangelogConfig = {
     size: 'h4',
     format: '`{{name}}@{{version}}`'
   },
+  rootChangesTitle: {
+    size: 'h3',
+    format: ':bookmark: Base changes'
+  },
+  moduleChangesTitle: {
+    size: 'h3',
+    format: ':package: Module changes'
+  },
   sectionSplitter: '---',
   typeSize: 'h3',
   typeMapping: {
@@ -47,6 +55,8 @@ export const CHANGELOG_DEFAULT_CONFIG: ChangelogConfig = {
     moduleTitle: true,
     attributionTitle: true,
     attributionSubTitle: true,
+    rootChangesTitle: true,
+    moduleChangesTitle: true,
     githubIssues: false,
     githubPullRequests: false,
     notes: true,

--- a/src/modules/changelog/generator.ts
+++ b/src/modules/changelog/generator.ts
@@ -222,15 +222,6 @@ class Generator {
     context: GeneratorContext
   ) {
     if (release.changes === undefined) return;
-    if (cfg.rootChangesTitle) {
-      builder.addHeader(
-        this._replacer.replaceEmojisIf(
-          cfg.rootChangesTitle.format,
-          cfg.replaceEmojis.rootChangesTitle
-        ),
-        cfg.rootChangesTitle.size
-      );
-    }
     for (const type of context.types) {
       const change = release.changes.filter((x) => x.type === type);
 

--- a/src/modules/changelog/generator.ts
+++ b/src/modules/changelog/generator.ts
@@ -172,35 +172,100 @@ class Generator {
     }
   }
 
+  private addChanges(
+    builder: MarkdownBuilder,
+    cfg: ChangelogConfig,
+    context: GeneratorContext,
+    changes: ChangelogEntry[]
+  ) {
+    changes.forEach((c) => {
+      builder.addListItem(
+        this._replacer.replaceEmojisIf(
+          c.description,
+          cfg.replaceEmojis.githubIssues
+        )
+      );
+
+      this.addGitHubMeta(c, builder, context);
+    });
+  }
+
+  private addTypeHeader(
+    builder: MarkdownBuilder,
+    cfg: ChangelogConfig,
+    type: string,
+    count?: number
+  ) {
+    const mappedTypeTitle = cfg.typeMapping[type];
+    if (mappedTypeTitle === undefined) {
+      console.warn('No mapping found for change type ' + type);
+    }
+
+    builder.addHeader(
+      this._replacer.replace(
+        this._replacer.replaceEmojisIf(
+          mappedTypeTitle,
+          cfg.replaceEmojis.types
+        ),
+        {
+          changeCount: count || undefined
+        }
+      ),
+      cfg.typeSize
+    );
+  }
+
+  private addRootChanges(
+    builder: MarkdownBuilder,
+    cfg: ChangelogConfig,
+    release: ChangelogDefinition,
+    context: GeneratorContext
+  ) {
+    if (release.changes === undefined) return;
+    if (cfg.rootChangesTitle) {
+      builder.addHeader(
+        this._replacer.replaceEmojisIf(
+          cfg.rootChangesTitle.format,
+          cfg.replaceEmojis.rootChangesTitle
+        ),
+        cfg.rootChangesTitle.size
+      );
+    }
+    for (const type of context.types) {
+      const change = release.changes.filter((x) => x.type === type);
+
+      if (change.length > 0) {
+        this.addTypeHeader(builder, cfg, type, change?.length);
+      }
+
+      const changes = release.changes?.filter((x) => x.type === type);
+      this.addChanges(builder, cfg, context, changes);
+    }
+  }
+
   private addModuleChanges(
     builder: MarkdownBuilder,
     cfg: ChangelogConfig,
     release: ChangelogDefinition,
     context: GeneratorContext
   ) {
+    if (cfg.moduleChangesTitle && release.changes !== undefined) {
+      builder.addHeader(
+        this._replacer.replaceEmojisIf(
+          cfg.moduleChangesTitle.format,
+          cfg.replaceEmojis.moduleChangesTitle
+        ),
+        cfg.moduleChangesTitle.size
+      );
+    }
+
     for (const type of context.types) {
       const change = release.modules.flatMap((y) =>
         y.changes.filter((x) => x.type === type)
       );
 
       if (change.length > 0) {
-        const mappedTypeTitle = cfg.typeMapping[type];
-        if (mappedTypeTitle === undefined) {
-          console.warn('No mapping found for change type ' + type);
-        }
-
-        builder.addHeader(
-          this._replacer.replace(
-            this._replacer.replaceEmojisIf(
-              mappedTypeTitle,
-              cfg.replaceEmojis.types
-            ),
-            {
-              changeCount: change?.length || undefined
-            }
-          ),
-          cfg.typeSize
-        );
+        this.addTypeHeader(builder, cfg, type, change?.length);
       }
 
       release.modules.forEach((rm) => {
@@ -222,16 +287,7 @@ class Generator {
             cfg.moduleTitleFormat.size
           );
 
-          change.forEach((c) => {
-            builder.addListItem(
-              this._replacer.replaceEmojisIf(
-                c.description,
-                cfg.replaceEmojis.githubIssues
-              )
-            );
-
-            this.addGitHubMeta(c, builder, context);
-          });
+          this.addChanges(builder, cfg, context, change);
         }
       });
     }
@@ -332,6 +388,7 @@ class Generator {
 
     this.addSectionHeader(builder, cfg, release);
     this.addSummaryAndNotes(builder, cfg, release);
+    this.addRootChanges(builder, cfg, release, context);
     this.addModuleChanges(builder, cfg, release, context);
     this.addContributors(builder, cfg, release, context);
     builder.addSplitter();

--- a/src/modules/changelog/models/changelog-config.ts
+++ b/src/modules/changelog/models/changelog-config.ts
@@ -18,4 +18,6 @@ export default interface ChangelogConfig {
   attributionTitleFormat: TitleFormat;
   attributionSubTitle: TitleFormat;
   replaceEmojis: ReplaceEmojiesConfig;
+  rootChangesTitle?: TitleFormat;
+  moduleChangesTitle?: TitleFormat;
 }

--- a/src/modules/changelog/models/changelog-config.ts
+++ b/src/modules/changelog/models/changelog-config.ts
@@ -18,6 +18,5 @@ export default interface ChangelogConfig {
   attributionTitleFormat: TitleFormat;
   attributionSubTitle: TitleFormat;
   replaceEmojis: ReplaceEmojiesConfig;
-  rootChangesTitle?: TitleFormat;
   moduleChangesTitle?: TitleFormat;
 }

--- a/src/modules/changelog/models/changelog-definition.ts
+++ b/src/modules/changelog/models/changelog-definition.ts
@@ -1,3 +1,4 @@
+import ChangelogEntry from './changelog-entry';
 import ChangelogModule from './changelog-module';
 
 export default interface ChangelogDefinition {
@@ -6,4 +7,5 @@ export default interface ChangelogDefinition {
   summary?: string;
   notes?: string;
   modules: ChangelogModule[];
+  changes?: ChangelogEntry[];
 }

--- a/src/modules/changelog/models/replace-emojis-config.ts
+++ b/src/modules/changelog/models/replace-emojis-config.ts
@@ -9,6 +9,5 @@ export default interface ReplaceEmojiesConfig {
   summary: boolean;
   githubIssues: boolean;
   githubPullRequests: boolean;
-  rootChangesTitle: boolean;
   moduleChangesTitle: boolean;
 }

--- a/src/modules/changelog/models/replace-emojis-config.ts
+++ b/src/modules/changelog/models/replace-emojis-config.ts
@@ -9,4 +9,6 @@ export default interface ReplaceEmojiesConfig {
   summary: boolean;
   githubIssues: boolean;
   githubPullRequests: boolean;
+  rootChangesTitle: boolean;
+  moduleChangesTitle: boolean;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = '0.2.3';
+export const LIB_VERSION = '0.3.0';


### PR DESCRIPTION
Add the ability to add changes on root for a release. These are changes that might be global or not directly connected to an individual module.

When adding root changes as well as changes in individual modules, these will be separated by a header. New configuration for this header is added.